### PR TITLE
(fix) Added quotes, so bash can interpret the parameters even with " " in them

### DIFF
--- a/scripts/open-lazygit.sh
+++ b/scripts/open-lazygit.sh
@@ -14,7 +14,7 @@ openLazygit () {
         -e LAZYGIT_EDITOR=$LAZYGIT_EDITOR \
         -e LAZYGIT_ORIGIN_PANE=$LAZYGIT_ORIGIN_PANE \
         lazygit \
-        -ucf $LAZYGIT_CONFIG,$CUSTOM_LAZYGIT_CONFIG
+        -ucf "$LAZYGIT_CONFIG,$CUSTOM_LAZYGIT_CONFIG"
 }
 
 openLazygit


### PR DESCRIPTION
There was a problem with bash interpreting the line where lazygit is launched, specially in MacOs where the default config directory is "/Users/<username>/Library/**Application Support**/lazygit/".

That space in **Application Support** was mistaken as a the parameter for lazygit, instead of being taken as part of the same parameter.