### PR TITLE
(fix) Added current path variable before opening lazygit in tmux

### DIFF
--- a/scripts/open-lazygit.sh
+++ b/scripts/open-lazygit.sh
@@ -8,9 +8,12 @@ LAZYGIT_CONFIG=$(echo "$(lazygit -cd)/config.yml")
 openLazygit () {
     # Gets the pane id from where the script was called
     local LAZYGIT_ORIGIN_PANE=($(tmux display-message -p "#D"))
+    
+    # Get the current working directory of the pane
+    local CURRENT_PATH=$(tmux display-message -p -t $LAZYGIT_ORIGIN_PANE "#{pane_current_path}")
 
     # Opens a new tmux window running lazygit appending the needed config
-    tmux neww \
+    tmux neww -c "$CURRENT_PATH" \
         -e LAZYGIT_EDITOR=$LAZYGIT_EDITOR \
         -e LAZYGIT_ORIGIN_PANE=$LAZYGIT_ORIGIN_PANE \
         lazygit \


### PR DESCRIPTION
I'm using WSL Ubuntu on Windows. Every time I open neolazygit on tmux, it doesn't open the current working directory but the $HOME directory. To fix this, I added a current path variable based on the active pane to ensure lazy git opens the correct directory. It's worked now on my machine, though.